### PR TITLE
Add Mud Cut voicing module and document pipeline

### DIFF
--- a/src/audio/voicing.ts
+++ b/src/audio/voicing.ts
@@ -1,0 +1,132 @@
+/**
+ * Psychoacoustic chord voicing utilities.
+ *
+ * Responsibilities:
+ * - Normalize raw chord spellings into playable voicings with octaves.
+ * - Enforce the "Mud Cut" rule: avoid major/minor 2nds below C3 to keep the low end clear.
+ * - Keep bass notes within roughly C2–G3 so the progression feels grounded without booming.
+ * - Provide simple voice-leading by nudging each chord's average pitch toward the previous chord.
+ */
+import { Note } from "@tonaljs/tonal";
+
+export type VoicedChord = {
+  notes: string[];
+};
+
+const DEFAULT_OCTAVE = 4;
+const BASS_MIN = Note.midi("C2") ?? 36;
+const BASS_MAX = Note.midi("G3") ?? 55;
+const MUD_CUTOFF = Note.midi("C3") ?? 48;
+const MAX_ITERATIONS = 8;
+
+export function voiceChord(baseNotes: string[], previousVoicing?: VoicedChord): VoicedChord {
+  let voicedMidis = normalizeNotes(baseNotes, true);
+  if (voicedMidis.length === 0) {
+    return { notes: [] };
+  }
+
+  voicedMidis = mapRootIntoBass(voicedMidis);
+  voicedMidis = enforceMudCut(voicedMidis);
+
+  if (previousVoicing && previousVoicing.notes.length > 0) {
+    const previousMidis = normalizeNotes(previousVoicing.notes, false);
+    if (previousMidis.length) {
+      voicedMidis = alignAverages(voicedMidis, previousMidis);
+      voicedMidis = enforceMudCut(voicedMidis);
+    }
+  }
+
+  const notes = voicedMidis
+    .sort((a, b) => a - b)
+    .map((midiValue) => Note.fromMidi(midiValue) ?? "C4");
+
+  return { notes };
+}
+
+export function describeVoicing(notes: string[]): string {
+  if (!notes.length) return "(empty voicing)";
+  return notes.join(" ");
+}
+
+function normalizeNotes(notes: string[], allowDefaultOctave: boolean): number[] {
+  const midis = notes
+    .map((note) => {
+      const hasOctave = /\d/.test(note);
+      const normalized = hasOctave || !allowDefaultOctave ? note : `${note}${DEFAULT_OCTAVE}`;
+      return Note.midi(normalized);
+    })
+    .filter((value): value is number => typeof value === "number");
+
+  return Array.from(new Set(midis)).sort((a, b) => a - b);
+}
+
+function mapRootIntoBass(midis: number[]): number[] {
+  if (!midis.length) return [];
+  const [root] = midis;
+  let shift = 0;
+
+  while (root + shift < BASS_MIN) {
+    shift += 12;
+  }
+  while (root + shift > BASS_MAX) {
+    shift -= 12;
+  }
+
+  return midis.map((value) => value + shift).sort((a, b) => a - b);
+}
+
+function enforceMudCut(midis: number[]): number[] {
+  const adjusted = [...midis].sort((a, b) => a - b);
+
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    let moved = false;
+    for (let i = 0; i < adjusted.length - 1; i++) {
+      const low = adjusted[i];
+      const high = adjusted[i + 1];
+      const interval = high - low;
+      if (low < MUD_CUTOFF && (interval === 1 || interval === 2)) {
+        adjusted[i + 1] = high + 12;
+        moved = true;
+        break;
+      }
+    }
+    if (!moved) {
+      break;
+    }
+    adjusted.sort((a, b) => a - b);
+  }
+
+  return adjusted;
+}
+
+function alignAverages(current: number[], previous: number[]): number[] {
+  if (!previous.length || !current.length) return current;
+  let result = [...current];
+  const previousAverage = average(previous);
+  let currentAverage = average(result);
+  let iterations = 0;
+
+  while (Math.abs(currentAverage - previousAverage) > 6 && iterations < MAX_ITERATIONS) {
+    result = result.map((value) =>
+      currentAverage > previousAverage ? value - 12 : value + 12
+    );
+    currentAverage = average(result);
+    iterations++;
+  }
+
+  return result.sort((a, b) => a - b);
+}
+
+function average(values: number[]): number {
+  if (!values.length) return 0;
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  return sum / values.length;
+}
+
+// Example: Csus2 low cluster
+// voiceChord(["C2", "D2", "G2"]) -> expected ["C2", "G2", "D3"]
+
+// Example: Smooth leading from Dm to G
+// const dMinor = voiceChord(["D", "F", "A"]);
+// const gMajor = voiceChord(["G", "B", "D"], dMinor);
+

--- a/src/lib/theory.ts
+++ b/src/lib/theory.ts
@@ -1,4 +1,5 @@
 import { Chord as TonalChord, Interval, Note } from "@tonaljs/tonal";
+import { voiceChord, VoicedChord } from "@/src/audio/voicing";
 import {
   generateProgression as generateHarmonyProgression,
   Mode as HarmonyMode,
@@ -18,23 +19,53 @@ export type ChordObject = {
   roman: string;
 };
 
-export type VoicingStrategy = 'closed' | 'open' | 'drop2';
+export type VoicingStrategy = "closed" | "open" | "drop2";
 
 /**
  * Apply voicing strategy to a set of notes
  * 'open' (default): Keeps root, moves 3rd up an octave, keeps/moves 5th
  */
-export function applyVoicing(notes: string[], strategy: VoicingStrategy = 'open'): string[] {
+export function applyVoicing(
+  notes: string[],
+  strategy: VoicingStrategy = "open",
+  previousNotes?: string[]
+): string[] {
+  if (!notes.length) {
+    return [];
+  }
+
+  try {
+    const previous: VoicedChord | undefined = previousNotes
+      ? { notes: previousNotes }
+      : undefined;
+    const voiced = voiceChord(notes, previous);
+    if (!voiced.notes.length) {
+      throw new Error("voiceChord returned empty notes");
+    }
+    return voiced.notes;
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn(
+        "[Harmonia] voiceChord failed, falling back to legacy voicing",
+        error
+      );
+    }
+    return legacyApplyVoicing(notes, strategy);
+  }
+}
+
+function legacyApplyVoicing(
+  notes: string[],
+  strategy: VoicingStrategy = "open"
+): string[] {
+  // Fallback path: identical to the original voicing logic while the new Mud Cut layer stabilizes.
   if (notes.length < 3) return notes;
-  
-  const pitchClasses = notes.map(n => Note.get(n).pc); // "C", "E", "G"
-  
-  if (strategy === 'closed') {
-    // Simple closed voicing: Root at C3, others immediately above
+
+  const pitchClasses = notes.map((n) => Note.get(n).pc);
+
+  if (strategy === "closed") {
     return pitchClasses.map((pc, i) => {
-      // Start at octave 3
       let octave = 3;
-      // If pitch class is 'lower' than root, bump octave
       if (i > 0) {
         const interval = Note.distance(pitchClasses[0] + octave, pc + octave);
         if (interval.startsWith("-")) octave++;
@@ -42,41 +73,38 @@ export function applyVoicing(notes: string[], strategy: VoicingStrategy = 'open'
       return pc + octave;
     });
   }
-  
-  if (strategy === 'open') {
-    const root = pitchClasses[0] + "3"; // Anchor root at octave 3
+
+  if (strategy === "open") {
+    const root = pitchClasses[0] + "3";
     const voicedNotes = [root];
-    
+
     for (let i = 1; i < pitchClasses.length; i++) {
       const pc = pitchClasses[i];
       let octave = 3;
-      
-      // Calculate base interval from root
+
       if (i === 1) {
-        // Move 3rd up one octave
         const baseNote = pc + "3";
         if (Note.distance(root, baseNote).startsWith("-")) {
-           octave = 5;
+          octave = 5;
         } else {
-           octave = 4;
+          octave = 4;
         }
       } else {
-        // 5th and 7th
-         const baseNote = pc + "3";
-         if (Note.distance(root, baseNote).startsWith("-")) {
-            octave = 4;
-         } else {
-            octave = 3;
-         }
+        const baseNote = pc + "3";
+        if (Note.distance(root, baseNote).startsWith("-")) {
+          octave = 4;
+        } else {
+          octave = 3;
+        }
       }
-      
+
       voicedNotes.push(pc + octave);
     }
-    
-    return voicedNotes.sort((a, b) => Note.midi(a)! - Note.midi(b)!);
+
+    return voicedNotes.sort((a, b) => (Note.midi(a) ?? 0) - (Note.midi(b) ?? 0));
   }
-  
-  return notes; // Fallback
+
+  return notes;
 }
 
 const SCALE_MODE_TO_ENGINE_MODE: Record<ScaleMode, HarmonyMode> = {
@@ -132,8 +160,8 @@ const ROMAN_INDEX: Record<string, number> = {
  * @param complexity Complexity level 0-3 (default: 1)
  */
 export function generateProgression(
-  root: string = "D", 
-  mode: ScaleMode = "minor", 
+  root: string = "D",
+  mode: ScaleMode = "minor",
   mood: Mood = "neutral",
   complexity: ComplexityLevel = 1
 ): ChordObject[] {
@@ -149,9 +177,21 @@ export function generateProgression(
     numChords: 4,
   });
 
-  return generated.map((generatedChord) =>
-    buildChordObject(root, harmonyMode, generatedChord)
-  );
+  const progression: ChordObject[] = [];
+  let previousNotes: string[] | undefined;
+
+  generated.forEach((generatedChord) => {
+    const chordObject = buildChordObject(
+      root,
+      harmonyMode,
+      generatedChord,
+      previousNotes
+    );
+    progression.push(chordObject);
+    previousNotes = chordObject.notes;
+  });
+
+  return progression;
 }
 
 export function generateDMinorProgression(mood: Mood = "neutral"): ChordObject[] {
@@ -161,12 +201,15 @@ export function generateDMinorProgression(mood: Mood = "neutral"): ChordObject[]
 function buildChordObject(
   root: string,
   harmonyMode: HarmonyMode,
-  generatedChord: GeneratedChord
+  generatedChord: GeneratedChord,
+  previousNotes?: string[]
 ): ChordObject {
   const chordSymbol = convertToChordSymbol(root, harmonyMode, generatedChord);
   const chord = TonalChord.get(chordSymbol);
   const chordNotes = chord.notes || [];
-  const voicedNotes = applyVoicing(chordNotes, "open");
+  // Symbolic chord → Tonal pitch classes → voiced via voiceChord (Mud Cut + voice-leading)
+  const previous = previousNotes && previousNotes.length ? previousNotes : undefined;
+  const voicedNotes = applyVoicing(chordNotes, "open", previous);
 
   return {
     symbol: chordSymbol,


### PR DESCRIPTION
Introduce src/audio/voicing.ts to centralize psychoacoustic rules: bass window (C2-G3), Mud Cut for low intervals, and average-based voice-leading with describeVoicing helper for dev diagnostics. Refactor applyVoicing in src/lib/theory.ts to delegate to voiceChord, thread previous chord notes through buildChordObject, and retain legacy voicing as the fallback with clear comments about the new pipeline.